### PR TITLE
feat: Courses endpoints

### DIFF
--- a/internal/firebase/db.go
+++ b/internal/firebase/db.go
@@ -285,6 +285,27 @@ func (c *Firestore) QueryBySchool(ctx context.Context, term, school string, limi
 	return c.collectCourses(ctx, query, limit, offset)
 }
 
+func (c *Firestore) GetCourseBySection(ctx context.Context, term string, prefix string, number string, section string) (*types.Course, error) {
+	term = normalizeTerm(term)
+	prefix = normalizeCoursePrefix(prefix)
+	number = normalizeCourseNumber(number)
+	section = strings.ToLower(strings.TrimSpace(section))
+
+	id := fmt.Sprintf("%s%s.%s.%s", prefix, number, section, term)
+
+	doc, err := c.Collection("courses").Doc(prefix).Collection("numbers").Doc(number).Collection("sections").Doc(id).Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var course types.Course
+	if err := doc.DataTo(&course); err != nil {
+		return nil, err
+	}
+
+	return &course, nil
+}
+
 func (c *Firestore) collectCourses(ctx context.Context, query firestore.Query, limit, offset int) ([]types.Course, bool, error) {
 	if limit > 0 {
 		query = query.Offset(offset).Limit(limit + 1)

--- a/internal/server/handlers/handlers.go
+++ b/internal/server/handlers/handlers.go
@@ -148,6 +148,28 @@ func (h *Handler) GetCoursesByNumber(c *gin.Context) {
 	})
 }
 
+func (h *Handler) GetCourseBySection(c *gin.Context) {
+	term := normalizeTerm(c.Param("term"))
+	prefix := normalizePrefix(c.Param("prefix"))
+	number := normalizeCourseNumber(c.Param("number"))
+	section := strings.TrimSpace(c.Param("section"))
+
+	if term == "" || prefix == "" || number == "" || section == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Term, prefix, number, and section parameters are required"})
+		return
+	}
+
+	course, err := h.db.GetCourseBySection(c.Request.Context(), term, prefix, number, section)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"course": course,
+	})
+}
+
 // SearchCourses runs a text search against courses for a term.
 func (h *Handler) SearchCourses(c *gin.Context) {
 	term := normalizeTerm(c.Param("term"))

--- a/internal/server/handlers/handlers.go
+++ b/internal/server/handlers/handlers.go
@@ -148,6 +148,7 @@ func (h *Handler) GetCoursesByNumber(c *gin.Context) {
 	})
 }
 
+// GetCourseBySection fetches a specific course by term, prefix, number, and section.
 func (h *Handler) GetCourseBySection(c *gin.Context) {
 	term := normalizeTerm(c.Param("term"))
 	prefix := normalizePrefix(c.Param("prefix"))

--- a/internal/server/handlers/handlers.go
+++ b/internal/server/handlers/handlers.go
@@ -46,7 +46,7 @@ func (h *Handler) GetAllCourses(c *gin.Context) {
 	})
 }
 
-// GetCoursesByTerm fetches courses and applies optional prefix/number filters.
+// GetCoursesByTerm fetches courses within a term.
 func (h *Handler) GetCoursesByTerm(c *gin.Context) {
 	term := normalizeTerm(c.Param("term"))
 	if term == "" {
@@ -59,23 +59,13 @@ func (h *Handler) GetCoursesByTerm(c *gin.Context) {
 		return
 	}
 
-	prefix := normalizePrefix(c.Query("prefix"))
-	number := normalizeCourseNumber(c.Query("number"))
-
 	var (
 		courses []types.Course
 		hasNext bool
 		err     error
 	)
 
-	switch {
-	case prefix != "" && number != "":
-		courses, hasNext, err = h.db.QueryByCourseNumber(c.Request.Context(), term, prefix, number, params.Limit, params.Offset)
-	case prefix != "":
-		courses, hasNext, err = h.db.QueryByCoursePrefix(c.Request.Context(), term, prefix, params.Limit, params.Offset)
-	default:
-		courses, hasNext, err = h.db.GetAllCoursesByTerm(c.Request.Context(), term, params.Limit, params.Offset)
-	}
+	courses, hasNext, err = h.db.GetAllCoursesByTerm(c.Request.Context(), term, params.Limit, params.Offset)
 
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/internal/server/router/router.go
+++ b/internal/server/router/router.go
@@ -30,6 +30,7 @@ func New(handler *handlers.Handler, mw *middleware.Manager) http.Handler {
 			courses.GET("/:term", handler.GetCoursesByTerm)
 			courses.GET("/:term/prefix/:prefix", handler.GetCoursesByPrefix)
 			courses.GET("/:term/prefix/:prefix/number/:number", handler.GetCoursesByNumber)
+			courses.GET("/:term/prefix/:prefix/number/:number/section/:section", handler.GetCourseBySection)
 			courses.GET("/:term/search", handler.SearchCourses)
 		}
 


### PR DESCRIPTION
Added CourseBySection endpoint to fetch info for a single specific course by section
Removed query parameters from CoursesByTerm because you can just use Courses by Prefix or Number


